### PR TITLE
Lock d3-rails version to D3.js

### DIFF
--- a/lib/d3/rails/version.rb
+++ b/lib/d3/rails/version.rb
@@ -1,6 +1,5 @@
 module D3
   module Rails
-    VERSION = "0.0.2"
-    D3_VERSION = "2.9.1"
+    VERSION = "2.9.1"
   end
 end


### PR DESCRIPTION
I was wondering if you would consider locking the gem version to the version of D3 it contains. Seems like this has a few advantages and no disadvantages that I can think of.

Primarily, it makes it easy identify which version of D3 will be included by looking at your gemfile.

Allows gems that depend on the D3 assets to use the pessimistic operator and rely on semver to have a better chance that updating D3 won't break the library.

On a side note, were you planning on pushing this up to rubygems.org?

Thanks for putting this gem together,

Chris
